### PR TITLE
[update] lintの設定更新

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,12 @@ const eslintConfig = [
   {
     rules: {
       "@stylistic/linebreak-style": ["error", "unix"],
+      "@stylistic/quote-props": ["error", "as-needed"],
+      "@stylistic/jsx-curly-spacing": [2, { when: "always" }],
+      "@stylistic/jsx-self-closing-comp": ["error", {
+        component: true,
+        html: true,
+      }],
     },
   },
 ];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${kosugiMaru.className} ${kosugiMaru.variable}`}>
+      <body className={ `${kosugiMaru.className} ${kosugiMaru.variable}` }>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import styles from "./page.module.css";
 
 export default function Home() {
   return (
-    <div className={styles.page}>
+    <div className={ styles.page }>
       TOP
     </div>
   );


### PR DESCRIPTION
- `"`を必要な場合のみに設定
- `{ hoge: "hoge" }`みたいなときにjsxの中括弧に空白を設定するのを必須に
- `<div></div>`のような子要素がないときに`<div />`というふうに書くように設定