### PR TITLE
[add] 記事ページのお試し：FrontMatterの分離お試し

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,0 +1,24 @@
+import fs from "fs";
+import matter from "gray-matter";
+
+export async function generateStaticParams() {
+  return [
+    { id: "20250429021614" }];
+}
+
+export default function ArticlePage() {
+  const raw = fs.readFileSync("_contents/articles/20250429021614.md", "utf-8");
+  const { data, content } = matter(raw);
+  return (
+    <div>
+      <h2>frontMatter</h2>
+      <p>
+        { JSON.stringify(data) }
+      </p>
+      <h2>content</h2>
+      <p>
+        { content}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
まずはページを用意して`generateStaticParams`とFrontMatterの分離がうまくいくかをお試し。

▼ 今はこんな感じになる（分離できてる！）  
![image](https://github.com/user-attachments/assets/59dcb113-03c7-4417-8d3b-f8fdab58261b)


## 途中で出たエラー

```txt
⨯ [Error: Page "/articles/[id]/page" is missing param "/articles/20250429021614" in "generateStaticParams()", which is required with "output: export" config.] {
  page: '/articles/20250429021614'
}
```

`[id]/page.tsx`にしているので、`generateStaticParams`で返すのは`[{id: "【idの値】"}]`にしないと行けないところを、  
`[{slug: "【idの値】"}]`にしちゃっててエラーになってた。

idにしたらいけた！