### PR TITLE
[update] 記事IDを持っていなければ、ユニークな記事IDを付与できるように変更

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,5 +1,11 @@
 import fs from "fs";
 import matter from "gray-matter";
+import { customAlphabet } from "nanoid";
+import path from "path";
+
+const articleDirectoryName = "_contents/articles";
+const articleIdCharacters = "0123456789abcdefghijklmnopqrstuvwxyz";
+const articleIdLength = 24;
 
 export async function generateStaticParams() {
   return [
@@ -9,13 +15,15 @@ export async function generateStaticParams() {
 export default function ArticlePage() {
   const raw = fs.readFileSync("_contents/articles/20250429021614.md", "utf-8");
   const { data, content } = matter(raw);
-  const frontMatter = { id: data.id ? data.id : "20250429021614", ...data };
+
+  // TODO：このIDを補ったデータをValibotで型検証する
+  const frontMatter = { id: data.id ? data.id : generateArticleId(), ...data };
   fs.writeFileSync("_contents/articles/20250429021614.md", matter.stringify(content, frontMatter));
   return (
     <div>
       <h2>frontMatter</h2>
       <p>
-        { JSON.stringify(data) }
+        { JSON.stringify(frontMatter) }
       </p>
       <h2>content</h2>
       <p>
@@ -23,4 +31,30 @@ export default function ArticlePage() {
       </p>
     </div>
   );
+}
+
+/**
+ * ユニークな記事IDの生成
+ * @returns ユニークな記事ID
+ * @todo ファイル分ける
+ */
+function generateArticleId(): string {
+  // TODO:後々記事のmetaをjsonなどにまとめたら、そっちを参照して未使用IDを取得するように変更してもよいかも
+  const usedIds = fs
+    .readdirSync(articleDirectoryName)
+    .filter(file => file.endsWith(".md"))
+    .map((file) => {
+      const raw = fs.readFileSync(path.join(articleDirectoryName, file), "utf-8");
+      const { data } = matter(raw);
+      return data.id;
+    });
+
+  let id: string = "";
+  const nanoid = customAlphabet(articleIdCharacters, articleIdLength);
+  do {
+    id = nanoid();
+  }
+  while (usedIds.includes(id));
+
+  return id;
 }


### PR DESCRIPTION
nanoidで小文字英数24桁で生成するように設定。

追加済みのマークダウンファイルにはまだ反映してません。  
後々自動で記事IDを付与するタイミングを検討中。