### PR TITLE
[update] コードブロックのツールコンテナをpreが含む形に入れ替え

### DIFF
--- a/src/lib/rehypePlugins/index.ts
+++ b/src/lib/rehypePlugins/index.ts
@@ -1,6 +1,7 @@
 import type { Element, Root } from "hast";
 import { visit } from "unist-util-visit";
 
+const codeContainerClassName = "code-container";
 const codeToolContainerClassName = "code-tools-container";
 
 /**
@@ -36,7 +37,7 @@ export function rehypeCodeToolContainer() {
     });
 
     for (const { pre, parent, index, lang } of targets) {
-      const container: Element = {
+      const toolContainer: Element = {
         type: "element",
         tagName: "div",
         properties: {
@@ -47,7 +48,18 @@ export function rehypeCodeToolContainer() {
         children: [],
       };
 
-      pre.children.unshift(container);
+      const codeContainer: Element = {
+        type: "element",
+        tagName: "div",
+        properties: {
+          className: [
+            codeContainerClassName,
+            `${codeContainerClassName}--${lang}`],
+        },
+        children: [toolContainer, pre],
+      };
+
+      parent.children.splice(index, 1, codeContainer);
     }
   };
 }
@@ -103,20 +115,20 @@ export function rehypeCopyButton() {
     visit(tree, "element", (node, _, parent) => {
       if (
         parent?.type === "element"
-        && parent.tagName === "pre"
+        && parent.tagName === "div"
+        && Array.isArray(parent.properties?.className)
+        && parent.properties.className.includes(codeContainerClassName)
         && node?.type === "element"
         && node.tagName === "div"
         && Array.isArray(node.properties?.className)
         && node.properties.className.includes(codeToolContainerClassName)
       ) {
-        console.log("found code tool container");
         const target = parent.children.find(child => child.type === "element"
-          && child.tagName === "code"
+          && child.tagName === "pre"
           && Array.isArray(child.properties?.className),
         );
 
         if (target && target.type === "element") {
-          console.log("found code");
           const targetId = `code-${uid++}`;
           target.properties = { ...target.properties, id: targetId };
 


### PR DESCRIPTION
前はpreをツールコンテナが含む形にしていましたが、ツールコンテナ部分の扱いやすさのために、  
コードコンテナを用意し、preとツールコンテナをコードコンテナで囲むようにしました。

![image](https://github.com/user-attachments/assets/53d84e69-dce6-4a20-9e3f-977a4765c7a7)
___
![localhost_3000_articles_20250429021614](https://github.com/user-attachments/assets/6a6549e0-2d1f-491b-8877-f83d62986f4f)