### PR TITLE
[update] cosole.logをエラーにするように設定

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ const eslintConfig = [
       jsdoc,
     },
     rules: {
+      "no-console": "error",
       "@stylistic/linebreak-style": ["error", "unix"],
       "@stylistic/quote-props": ["error", "as-needed"],
       "@stylistic/jsx-curly-spacing": [2, { when: "always" }],


### PR DESCRIPTION
別PRでconsole.logを入れっぱなしにしわすれそうだったので追加。

https://eslint.org/docs/latest/rules/no-console

![localhost_3000_articles_20250429021614](https://github.com/user-attachments/assets/6a6549e0-2d1f-491b-8877-f83d62986f4f)
