### PR TITLE
[update] ESLintで引数分解していてもコメントをつけるように変更

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,7 +37,6 @@ const eslintConfig = [
         component: true,
         html: true,
       }],
-      "jsdoc/require-param": ["error", { checkDestructuredRoots: false }], // 分割している引数の時はエラーにしない
       "jsdoc/require-jsdoc": ["error", { publicOnly: true }],
     },
   },

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -94,6 +94,8 @@ export async function generateStaticParams(): Promise<Params[]> {
 
 /**
  * 記事ページのコンポーネント
+ * @param root0 引数オブジェクト
+ * @param root0.params 記事のIDを含むパラメータ
  * @returns 記事ページのJSX要素
  */
 export default async function ArticlePage({ params }: { params: Promise<Params> }) {

--- a/src/components/TextBlock/TextBlock.tsx
+++ b/src/components/TextBlock/TextBlock.tsx
@@ -27,6 +27,10 @@ type Props = {
 
 /**
  * テキストブロックコンポーネント
+ * @param root0 引数オブジェクト
+ * @param root0.title テキストブロックのタイトル
+ * @param root0.titleLevel テキストブロックのタイトルレベル
+ * @param root0.children 子要素
  * @returns テキストブロックコンポーネント
  * @todo 後でちゃんと定義する。今はStorybookのサンプルをこれに置き換えておくために途中の状態。
  */


### PR DESCRIPTION
Componentなどの引数の説明が見えやすいように、引数を分解している場合もドキュメントをつけるように変更