### PR TITLE
[update] インラインコードの見た目設定

### DIFF
--- a/_contents/articles/test.md
+++ b/_contents/articles/test.md
@@ -12,6 +12,8 @@ description: お試しページデータ。後で消す。
 ---
 ## 見出し2
 
+`inline code`です。
+
 https://www.google.com/
 
 [https://www.google.com/](https://www.google.com/)

--- a/src/app/globalElement.css
+++ b/src/app/globalElement.css
@@ -69,7 +69,7 @@
     --color-code-tool-background: #f8f9fa;
     --color-inline-code-background: #f1f3f4;
     --color-inline-code-text: #c7254e;
-    --color-inline-code-border: rgba(0, 0, 0, 0.1);
+    --color-inline-code-border: rgba(0 0 0 / 10%);
     
     /* background image */
   
@@ -133,7 +133,7 @@
     --color-code-tool-background: #21262d;
     --color-inline-code-background: #3c4043;
     --color-inline-code-text: #ff6b6b;
-    --color-inline-code-border: rgba(255, 255, 255, 0.15);
+    --color-inline-code-border: rgba(255 255 255 / 15%);
 
     /* background image */
     

--- a/src/app/globalElement.css
+++ b/src/app/globalElement.css
@@ -67,6 +67,9 @@
     --color-code-text-default: black;
     --color-code-border: #dfdfdf;
     --color-code-tool-background: #f8f9fa;
+    --color-inline-code-background: #f1f3f4;
+    --color-inline-code-text: #c7254e;
+    --color-inline-code-border: rgba(0, 0, 0, 0.1);
     
     /* background image */
   
@@ -128,6 +131,9 @@
     --color-code-text-default: #f8f8f2;
     --color-code-border: #505050;
     --color-code-tool-background: #21262d;
+    --color-inline-code-background: #3c4043;
+    --color-inline-code-text: #ff6b6b;
+    --color-inline-code-border: rgba(255, 255, 255, 0.15);
 
     /* background image */
     

--- a/src/components/server/Article/Article.tsx
+++ b/src/components/server/Article/Article.tsx
@@ -25,6 +25,7 @@ import remarkGfm from "remark-gfm";
 import styles from "./Article.module.css";
 import "./list.css";
 import "./prism.css"; // 記事内で使用するコードハイライトのPrismのスタイルを適用するためにインポート
+import "./inlineCode.css"; // インラインコードのスタイルを適用するためにインポート
 
 const DynamicToc = dynamic(() => import("@/components/TableOfContents").then(mod => mod.TableOfContents));
 const DynamicCodeCopyHandler = dynamic(() => import("@/components/CopyCodeHandler").then(mod => mod.default));

--- a/src/components/server/Article/inlineCode.css
+++ b/src/components/server/Article/inlineCode.css
@@ -1,0 +1,19 @@
+/* インラインコードのスタイル - article-contents-container内でのみ適用 */
+.article-contents-container :not(pre) > code {
+  position: relative;
+  padding: 0.2em 0.4em;
+  border-radius: 0.3em;
+  color: var(--color-inline-code-text);
+  border: 1px solid var(--color-inline-code-border);
+  background-color: var(--color-inline-code-background);
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 0.9em;
+  white-space: nowrap;
+  box-sizing: border-box;
+}
+
+/* インラインコードが長い場合の処理 */
+.article-contents-container :not(pre) > code.long-code {
+  white-space: normal;
+  word-break: break-all;
+}

--- a/src/components/server/Article/prism.css
+++ b/src/components/server/Article/prism.css
@@ -59,18 +59,7 @@ pre[class*="language-"] {
     hyphens: none;
 }
 
-/* Inline code */
-:not(pre) > code[class*="language-"] {
-    position: relative;
-    padding: .2em;
-    border-radius: 0.3em;
-    color: #c92c2c;
-    border: 1px solid rgba(0 0 0 / 10%);
-    display: inline;
-    white-space: normal;
-    background-color: #fdfdfd;
-    box-sizing: border-box;
-}
+/* Inline code - このスタイルは inlineCode.css に移動しました */
 
 .token.comment,
 .token.block-comment,


### PR DESCRIPTION
|light|dark|
|--|--|
|<img width="173" height="35" alt="image" src="https://github.com/user-attachments/assets/83ec5057-29c4-4443-8aa4-8360a645d15a" />|<img width="178" height="36" alt="image" src="https://github.com/user-attachments/assets/213aabb3-9f98-4c8d-b426-ef905d452c02" />|