### PR TITLE
[update] 引用のスタイル設定

### DIFF
--- a/_contents/articles/test.md
+++ b/_contents/articles/test.md
@@ -18,6 +18,15 @@ https://www.google.com/
 
 [https://www.google.com/](https://www.google.com/)
 
+> これは1行の引用です。
+
+この行は引用ではありません。
+
+> 複数行の引用の1行目です。  
+> 複数行の引用の2行目です。  
+> 複数行の引用の3行目です。
+
+
 ```cs
 var hoge = "hogehoge";
 var hoge = "hogehoge";

--- a/src/app/globalElement.css
+++ b/src/app/globalElement.css
@@ -122,7 +122,9 @@
     --icon-color-tip: #ffb74d;
     --color-block-question: #2e2548;
     --icon-color-question: #b39ddb;
-    --color-block-quote: #d8d8d8;
+    --color-block-quote: #3a3a3a;
+    --icon-color-quote: #6b6b6b;
+    --text-color-quote: #d0d0d0;
 
     /* code color */
 

--- a/src/components/server/Article/Article.tsx
+++ b/src/components/server/Article/Article.tsx
@@ -26,6 +26,7 @@ import styles from "./Article.module.css";
 import "./list.css";
 import "./prism.css"; // 記事内で使用するコードハイライトのPrismのスタイルを適用するためにインポート
 import "./inlineCode.css"; // インラインコードのスタイルを適用するためにインポート
+import "./blockquote.css"; // 引用のスタイルを適用するためにインポート
 
 const DynamicToc = dynamic(() => import("@/components/TableOfContents").then(mod => mod.TableOfContents));
 const DynamicCodeCopyHandler = dynamic(() => import("@/components/CopyCodeHandler").then(mod => mod.default));

--- a/src/components/server/Article/blockquote.css
+++ b/src/components/server/Article/blockquote.css
@@ -39,13 +39,13 @@
 
 /* 引用内のコード */
 .article-contents-container blockquote code {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0 0 0 / 5%);
   color: inherit;
 }
 
 /* ダークモードでの引用内コード */
 @media (prefers-color-scheme: dark) {
   .article-contents-container blockquote code {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(255 255 255 / 10%);
   }
 }

--- a/src/components/server/Article/blockquote.css
+++ b/src/components/server/Article/blockquote.css
@@ -1,0 +1,51 @@
+/* 引用（blockquote）のスタイル - article-contents-container内でのみ適用 */
+.article-contents-container blockquote {
+  position: relative;
+  margin: 1.5em 0;
+  padding: 1em 1em 1em 3em;
+  background-color: var(--color-block-quote);
+  border-left: 4px solid var(--icon-color-quote);
+  color: var(--text-color-quote);
+  font-style: italic;
+}
+
+/* 引用アイコン（引用符）を擬似要素で表示 */
+.article-contents-container blockquote::before {
+  content: '"';
+  position: absolute;
+  left: 0.5em;
+  top: 0.25em;
+  font-size: 3em;
+  font-weight: bold;
+  color: var(--icon-color-quote);
+  font-family: Georgia, serif;
+  line-height: 1;
+}
+
+/* 引用内の段落の間隔調整 */
+.article-contents-container blockquote p {
+  margin: 0;
+}
+
+.article-contents-container blockquote p + p {
+  margin-top: 0.5em;
+}
+
+/* ネストされた引用 */
+.article-contents-container blockquote blockquote {
+  margin: 0.5em 0;
+  font-size: 0.95em;
+}
+
+/* 引用内のコード */
+.article-contents-container blockquote code {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: inherit;
+}
+
+/* ダークモードでの引用内コード */
+@media (prefers-color-scheme: dark) {
+  .article-contents-container blockquote code {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+}


### PR DESCRIPTION
|light|dark|
|--|--|
|<img width="620" height="207" alt="image" src="https://github.com/user-attachments/assets/1ef800ac-8186-4466-ae91-d2602ff873a0" />|<img width="631" height="226" alt="image" src="https://github.com/user-attachments/assets/e722e889-ec20-41ed-825c-ffac68fba66a" />|