### PR TITLE
[update] パッケージのバージョンをタグに合わせて変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homimemo",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "npm run build:json && run-p dev:*",


### PR DESCRIPTION
Next.jsへのリニューアル後は2.0という扱いでタグを切ってあるので、パッケージのバージョンも合わせます。