### PR TITLE
[fix] sitemapの記事リストページのページ数の出力をミスっていたので修正

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,7 +32,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const articleListPages: MetadataRoute.Sitemap = getPageLength(
     allArticles.length
   ).map((i) => ({
-    url: `${siteOrigin}${createArticleListPagePath(i + 1)}`,
+    url: `${siteOrigin}${createArticleListPagePath(i)}`,
     lastModified: new Date(),
     changeFrequency: "weekly",
   }));


### PR DESCRIPTION
Googleのインデックスエラーで404があって気付きました。

`/sitemap.xml`で`https://homironi.com/articles/page/3/`が消えて`https://homironi.com/articles/page/1/`が変わりに出てくればOK（2は今もあるし、修正後も必要）