### PR TITLE
[update] 記事リンクのComponentで日付表示を見やすく調整

### DIFF
--- a/src/components/ArticleLink/ArticleLink.module.css
+++ b/src/components/ArticleLink/ArticleLink.module.css
@@ -69,6 +69,10 @@
 
 .date-container{
     text-align: right;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0 0.5rem;
 }
 
 .category,
@@ -82,8 +86,4 @@
     width: 1rem;
     height: 1rem;
     vertical-align: -0.2em;
-}
-
-.last-mod-date{
-    margin-right: 0.5rem;
 }

--- a/src/components/ArticleLink/ArticleLink.tsx
+++ b/src/components/ArticleLink/ArticleLink.tsx
@@ -50,7 +50,7 @@ export function ArticleLink({ meta }: ArticleLinkProps) {
           <div className={ styles.description }>{meta.description}</div>
           <div className={ styles["date-container"] }>
             {lastModDate !== publishDate && (
-              <span className={ styles["last-mod-date"] }>
+              <span>
                 <LastModeDateIcon className={ styles.icon } />
                 <time dateTime={ formatDate(meta.lastModDate, "YYYY-MM-DD") }>
                   {lastModDate}


### PR DESCRIPTION

|Before|After|
|--|--|
|<img width="308" height="191" alt="image" src="https://github.com/user-attachments/assets/5c2a9b8c-277e-435d-a275-9e300879aeda" />|<img width="306" height="192" alt="image" src="https://github.com/user-attachments/assets/69f124f2-d8cf-45a8-8aa7-f003c3b7ce17" />|
