### PR TITLE
[update] liのpaddingを調整

### DIFF
--- a/src/components/server/Article/list.css
+++ b/src/components/server/Article/list.css
@@ -4,8 +4,12 @@
 .article-contents-container ul li,
 .article-contents-container ol li {
     position: relative;
-    padding-left: 2em;
+    padding-left: 1em;
     line-height: 1.5em;
+}
+
+.article-contents-container ol li {
+    padding-left: 1.5em;
 }
 
 .article-contents-container ul li::before,


### PR DESCRIPTION
<img width="358" height="311" alt="image" src="https://github.com/user-attachments/assets/c3e27e43-db5a-4067-9cf0-d26ac9b7ca0f" />

<img width="303" height="237" alt="image" src="https://github.com/user-attachments/assets/fcca4d58-7fb5-49b8-b894-c66ab764fe1d" />

<img width="216" height="89" alt="image" src="https://github.com/user-attachments/assets/9499ca31-85c1-406b-86dc-04536f8e3982" />

<img width="232" height="158" alt="image" src="https://github.com/user-attachments/assets/10ae42cf-469a-4fc6-bffb-1496fd8ec16e" />
