### PR TITLE
[update] モバイルのレイアウトシフト回避のため、目次の高さを固定に変更

### DIFF
--- a/src/components/TableOfContents/TableOfContents.module.css
+++ b/src/components/TableOfContents/TableOfContents.module.css
@@ -15,6 +15,6 @@
 
 @media screen and (width <= 500px){
     .container{
-        max-height: calc(40vh - var(--padding-toc) * 4);
+        height: calc(40vh - var(--padding-toc) * 4);
     }
 }


### PR DESCRIPTION
少なめでも許容できる見た目なので、モバイルは目次高さを固定

<img width="492" height="475" alt="image" src="https://github.com/user-attachments/assets/b7ded19e-3e8d-479d-89c4-7e4efd2c65fe" />
