### PR TITLE
release/2025-10-04-21-03

### DIFF
--- a/src/components/server/Article/prism.css
+++ b/src/components/server/Article/prism.css
@@ -13,7 +13,7 @@
 
 .code-highlight > span {
     display: block;
-    margin: 0 0.5em;
+    padding: 0 0.5em;
 }
 
 .code-highlight > span,


### PR DESCRIPTION
背景色がmarginなので反映されてなかった

▼ `/articles/teuoslm5qrtzhh4lqkqlm34a/`

<img width="408" height="192" alt="image"
src="https://github.com/user-attachments/assets/cbae1810-e9ec-421e-ad89-a6ce873aaa41" />