### PR TITLE
[update] og:imageのURLはあるのに404になっているので一時除外

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,6 +5,8 @@
 root_dir = "./_public"
 
 exclude = [
+    # og:imageのURLはあるのに404になっているので一時除外
+    'https://expressive-code\.com/open-graph/.*\.png',
     # HTTP/2エラーが出るドメイン
     'https://www\.adobe\.com/.*',
     'https://helpx\.adobe\.com/.*',


### PR DESCRIPTION
og:imageは変わってないけど、画像自体は404になっているのでしばらく除外しておく

- https://expressive-code.com/installation/#astro
- https://expressive-code.com/
- https://expressive-code.com/guides/themes/